### PR TITLE
Add Space key to AWTInputProvider

### DIFF
--- a/desktop-awt/src/main/scala/sgl/awt/AWTInputProvider.scala
+++ b/desktop-awt/src/main/scala/sgl/awt/AWTInputProvider.scala
@@ -19,6 +19,8 @@ trait AWTInputProvider extends InputProvider {
   }
 
   private def keyEventKey(e: KeyEvent): Option[Input.Keys.Key] = e.getKeyCode match {
+    case KeyEvent.VK_SPACE => Some(Input.Keys.Space)
+
     case KeyEvent.VK_LEFT => Some(Input.Keys.Left)
     case KeyEvent.VK_UP => Some(Input.Keys.Up)
     case KeyEvent.VK_RIGHT => Some(Input.Keys.Right)


### PR DESCRIPTION
Simple PR to add `Space` as an input key to `AWTInputProvider`.
I put it at the top to match `Html5InputProvider`.