### PR TITLE
Patch tests, add CI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ target
 .history
 *.swp
 *.swo
+.metals/
+.bloop/
+project/metals.sbt

--- a/README.md
+++ b/README.md
@@ -189,3 +189,7 @@ cake pattern for dependencies injection is [this
 one](http://jonasboner.com/real-world-scala-dependency-injection-di/).  There
 is also a [great talk](https://www.youtube.com/watch?v=yLbdw06tKPQ) that
 describes how to use the cake pattern, which closely ressembles our usage here.
+
+## Developing
+
+In order to run the tests for scala-native, you will need to follow the installation instructions on the Scala Native [website](https://scala-native.readthedocs.io/en/v0.3.9-docs/user/setup.html#installing-clang-and-runtime-dependencies) if you have not done so already.

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val coreAndroid = (project in file("./core"))
   .settings(commonAndroidSettings: _*)
   .settings(
     name         := "sgl-core-android",
-    target       := baseDirectory.value / ".android" / "target"
+    target       := baseDirectory.value / ".android" / "target",
+    libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.0" % "test"
   )
 
 lazy val jvmShared = (project in file("./jvm-shared"))
@@ -332,3 +333,20 @@ lazy val MacName = "Mac OS X"
 
 def isLinux(name: String): Boolean = name.startsWith(LinuxName.toLowerCase)
 def isMac(name: String): Boolean = name.startsWith(MacName.toLowerCase)
+
+/** Currently, the native projects are not compiling due to binary incompatibility
+ * with scalatest. Once this issue is resolved, we can revert back to the CI
+ * command being `sbt test`. For now, this hackily ensures that we don't regress
+ * being on everything else.
+ * 
+ * Missing projects from this command: coreNative, jvmSharedAndroid, platformerDesktopNative.
+ */
+lazy val verifyCiCommand = List(
+  "coreJVM","desktopAWT","desktopNative","helloCoreJS","helloCoreJVM","helloCoreNative",
+  "helloDesktopAWT","helloDesktopNative","helloHtml5","html5","jvmShared","menuCoreJS",
+  "menuCoreJVM","menuCoreNative","menuDesktopAWT","platformerCoreJS","platformerCoreJVM",
+  "platformerCoreNative","platformerDesktopAWT","snakeCoreJS","snakeCoreJVM","snakeCoreNative",
+  "snakeDesktopAWT","snakeDesktopNative","snakeHtml5"
+).map(_ + "/test").mkString("; ")
+
+addCommandAlias("verifyCI", s"; $verifyCiCommand")

--- a/core/src/test/scala/sgl/TestGraphicsProvider.scala
+++ b/core/src/test/scala/sgl/TestGraphicsProvider.scala
@@ -83,7 +83,6 @@ trait TestGraphicsProvider extends GraphicsProvider {
       override def drawString(str: String, x: Float, y: Float, paint: Paint): Unit = ???
       override def drawText(text: TextLayout, x: Float, y: Float): Unit = ???
       override def drawColor(color: Color): Unit = ???
-      override def clearRect(x: Float, y: Float, width: Float, height: Float): Unit = ???
       override def renderText(text: String, width: Int, paint: Paint): TextLayout = ???
     }
     type Canvas = TestCanvas

--- a/core/src/test/scala/sgl/TestSystemProvider.scala
+++ b/core/src/test/scala/sgl/TestSystemProvider.scala
@@ -11,6 +11,9 @@ trait TestSystemProvider extends SystemProvider {
     def exit(): Unit = ???
     def millis(): Long = ???
 
+    def currentTimeMillis: Long = ???
+    def nanoTime: Long = ???
+
     def loadText(path: ResourcePath): Loader[Array[String]] = ???
 
     def loadBinary(path: ResourcePath): Loader[Array[Byte]] = ???

--- a/core/src/test/scala/sgl/geometry/CollisionsSuite.scala
+++ b/core/src/test/scala/sgl/geometry/CollisionsSuite.scala
@@ -5,23 +5,23 @@ import org.scalatest.FunSuite
 class CollisionsSuite extends FunSuite {
 
   test("polygonWithPolygonSat with simple rects") {
-    val p1 = Polygon(Array(Vec(0,0), Vec(0, 10), Vec(10, 10), Vec(10, 0)))
-    val p2 = Polygon(Array(Vec(5,5), Vec(5, 15), Vec(15, 15), Vec(15, 5)))
+    val p1 = Polygon(Vector(Vec(0,0), Vec(0, 10), Vec(10, 10), Vec(10, 0)))
+    val p2 = Polygon(Vector(Vec(5,5), Vec(5, 15), Vec(15, 15), Vec(15, 5)))
     assert(Collisions.polygonWithPolygonSat(p1, p2))
     assert(Collisions.polygonWithPolygonSat(p2, p1))
 
-    val p3 = Polygon(Array(Vec(15,15), Vec(15, 20), Vec(20, 20), Vec(20, 15)))
+    val p3 = Polygon(Vector(Vec(15,15), Vec(15, 20), Vec(20, 20), Vec(20, 15)))
     assert(!Collisions.polygonWithPolygonSat(p1, p3))
     assert(!Collisions.polygonWithPolygonSat(p3, p1))
   }
 
   test("polygonWithPolygonSat with triangles") {
-    val p1 = Polygon(Array(Vec(0,0), Vec(2, 10), Vec(8, 4)))
-    val p2 = Polygon(Array(Vec(4,4), Vec(10, 10), Vec(11, 1)))
+    val p1 = Polygon(Vector(Vec(0,0), Vec(2, 10), Vec(8, 4)))
+    val p2 = Polygon(Vector(Vec(4,4), Vec(10, 10), Vec(11, 1)))
     assert(Collisions.polygonWithPolygonSat(p1, p2))
     assert(Collisions.polygonWithPolygonSat(p2, p1))
 
-    val p3 = Polygon(Array(Vec(12,0), Vec(13, 8), Vec(17, 4.5f)))
+    val p3 = Polygon(Vector(Vec(12,0), Vec(13, 8), Vec(17, 4.5f)))
     assert(!Collisions.polygonWithPolygonSat(p1, p3))
     assert(!Collisions.polygonWithPolygonSat(p3, p1))
   }

--- a/core/src/test/scala/sgl/geometry/PolygonSuite.scala
+++ b/core/src/test/scala/sgl/geometry/PolygonSuite.scala
@@ -5,7 +5,7 @@ import org.scalatest.FunSuite
 class PolygonSuite extends FunSuite {
 
   test("Create polygon with correct vertices and edges") {
-    val p = Polygon(Array(Vec(0,0), Vec(1, 10), Vec(5, 5)))
+    val p = Polygon(Vector(Vec(0,0), Vec(1, 10), Vec(5, 5)))
     assert(p.vertices(0) === Vec(0,0))
     assert(p.vertices(1) === Vec(1,10))
     assert(p.vertices(2) === Vec(5,5))
@@ -19,7 +19,7 @@ class PolygonSuite extends FunSuite {
   }
 
   test("Correct bounding box for polygon") {
-    val p = Polygon(Array(Vec(0, 5), Vec(3, 8), Vec(7, 4), Vec(4, -2)))
+    val p = Polygon(Vector(Vec(0, 5), Vec(3, 8), Vec(7, 4), Vec(4, -2)))
     val bb = p.boundingBox
     assert(bb.top == -2)
     assert(bb.left == 0)

--- a/examples/menu/core/src/main/scala/MainScreen.scala
+++ b/examples/menu/core/src/main/scala/MainScreen.scala
@@ -26,9 +26,8 @@ trait ScreensComponent {
     scene.addNode(levelsPane)
 
     class LevelButton(i: Int, _x: Float, _y: Float) extends Button(_x, _y, 100, 30) {
-      override def notifyClick(x: Float, y: Float): Boolean = {
+      override def notifyClick(x: Float, y: Float): Unit = {
         println(s"button $i clicked at ($x, $y)")
-        true
       }
       override def renderPressed(canvas: Graphics.Canvas): Unit = {
         val color = Graphics.defaultPaint.withColor(Graphics.Color.Red)


### PR DESCRIPTION
I was able to get a majority* of the tests working fairly easily, but there are some issues with scalatest and scala-native, and I didn't want to delay these positive changes.

- Add a high-level `verifyCI` sbt command. I think this gets things in a better state and ensures nothing regresses while the other issues are worked out.
- Add `scalatest` as a dependency to a few projects that needed it.
- Update the README with instructions on installing native binaries. This allowed me to compile the core native project.

(* everything but `coreNative`, `jvmSharedAndroid`, and `platformerDesktopNative`)

https://github.com/regb/scala-game-library/issues/7