### PR TITLE
add circle/rect vec ops

### DIFF
--- a/core/src/main/scala/sgl/geometry/Circle.scala
+++ b/core/src/main/scala/sgl/geometry/Circle.scala
@@ -10,6 +10,9 @@ case class Circle(x: Float, y: Float, radius: Float) {
   def right: Float = x + radius
   def bottom: Float = y + radius
 
+  def +(m: Vec): Circle = Circle(x + m.x, y + m.y, radius)
+  def -(m: Vec): Circle = Circle(x - m.x, y - m.y, radius)
+
   def intersect(x: Float, y: Float): Boolean = {
     val d2 = (x - this.x)*(x - this.x) + (y - this.y)*(y - this.y)
     d2 <= radius*radius

--- a/core/src/main/scala/sgl/geometry/Rect.scala
+++ b/core/src/main/scala/sgl/geometry/Rect.scala
@@ -1,7 +1,7 @@
 package sgl.geometry
 
 /** an AABB Rect. */
-class Rect(var left: Float, var top: Float, var width: Float, var height: Float) {
+case class Rect(left: Float, top: Float, width: Float, height: Float) {
 
   def right: Float = left + width
   def bottom: Float = top + height
@@ -9,6 +9,9 @@ class Rect(var left: Float, var top: Float, var width: Float, var height: Float)
   def centerX = left + width/2
   def centerY = top + height/2
   def center: Point = Point(centerX, centerY)
+
+  def +(m: Vec): Rect = Rect(left + m.x, top + m.x, width, height)
+  def -(m: Vec): Rect = Rect(left - m.x, top - m.y, width, height)
 
   /*
    * names are inversed with (x,y) coordinates, unfortunate...
@@ -36,8 +39,6 @@ class Rect(var left: Float, var top: Float, var width: Float, var height: Float)
 }
 
 object Rect {
-
-  def apply(left: Float, top: Float, width: Float, height: Float) = new Rect(left, top, width, height)
 
   def fromBoundingBox(left: Float, top: Float, right: Float, bottom: Float): Rect =
     Rect(left, top, right - left, bottom - top)

--- a/core/src/main/scala/sgl/geometry/Rect.scala
+++ b/core/src/main/scala/sgl/geometry/Rect.scala
@@ -10,7 +10,7 @@ case class Rect(left: Float, top: Float, width: Float, height: Float) {
   def centerY = top + height/2
   def center: Point = Point(centerX, centerY)
 
-  def +(m: Vec): Rect = Rect(left + m.x, top + m.x, width, height)
+  def +(m: Vec): Rect = Rect(left + m.x, top + m.y, width, height)
   def -(m: Vec): Rect = Rect(left - m.x, top - m.y, width, height)
 
   /*

--- a/core/src/main/scala/sgl/geometry/Rect.scala
+++ b/core/src/main/scala/sgl/geometry/Rect.scala
@@ -1,7 +1,7 @@
 package sgl.geometry
 
 /** an AABB Rect. */
-case class Rect(left: Float, top: Float, width: Float, height: Float) {
+class Rect(var left: Float, var top: Float, var width: Float, var height: Float) {
 
   def right: Float = left + width
   def bottom: Float = top + height
@@ -39,6 +39,8 @@ case class Rect(left: Float, top: Float, width: Float, height: Float) {
 }
 
 object Rect {
+
+  def apply(left: Float, top: Float, width: Float, height: Float) = new Rect(left, top, width, height)
 
   def fromBoundingBox(left: Float, top: Float, right: Float, bottom: Float): Rect =
     Rect(left, top, right - left, bottom - top)

--- a/core/src/test/scala/sgl/geometry/CircleSuite.scala
+++ b/core/src/test/scala/sgl/geometry/CircleSuite.scala
@@ -1,0 +1,20 @@
+package sgl.geometry
+
+import org.scalatest.FunSuite
+
+class CircleSuite extends FunSuite {
+
+  test("adds a Vec") {
+    val c = Circle(0, 0, 10)
+    val v = Vec(1, 1)
+    val expected = Circle(1,1,10)
+    assert(c + v === expected)
+  }
+
+  test("subtracts a Vec") {
+    val c = Circle(0, 0, 10)
+    val v = Vec(1, 1)
+    val expected = Circle(-1,-1,10)
+    assert(c - v === expected)
+  }
+}

--- a/core/src/test/scala/sgl/geometry/RectSuite.scala
+++ b/core/src/test/scala/sgl/geometry/RectSuite.scala
@@ -23,4 +23,18 @@ class RectSuite extends FunSuite {
     assert(!r1.intersect(11, 10))
     assert(!r1.intersect(5, 25))
   }
+
+  test("adds a Vec") {
+    val r = Rect(0,0,10,10)
+    val v = Vec(1,1)
+    val expected = Rect(1,1,10,10)
+    assert(r + v === expected)
+  }
+  
+  test("subtracts a Vec") {
+    val r = Rect(0,0,10,10)
+    val v = Vec(1,1)
+    val expected = Rect(-1,-1,10,10)
+    assert(r - v === expected)
+  }
 }

--- a/core/src/test/scala/sgl/geometry/RectSuite.scala
+++ b/core/src/test/scala/sgl/geometry/RectSuite.scala
@@ -26,15 +26,15 @@ class RectSuite extends FunSuite {
 
   test("adds a Vec") {
     val r = Rect(0,0,10,10)
-    val v = Vec(1,1)
-    val expected = Rect(1,1,10,10)
+    val v = Vec(1,2)
+    val expected = Rect(1,2,10,10)
     assert(r + v === expected)
   }
   
   test("subtracts a Vec") {
     val r = Rect(0,0,10,10)
-    val v = Vec(1,1)
-    val expected = Rect(-1,-1,10,10)
+    val v = Vec(1,2)
+    val expected = Rect(-1,-2,10,10)
     assert(r - v === expected)
   }
 }

--- a/core/src/test/scala/sgl/geometry/RectSuite.scala
+++ b/core/src/test/scala/sgl/geometry/RectSuite.scala
@@ -28,13 +28,21 @@ class RectSuite extends FunSuite {
     val r = Rect(0,0,10,10)
     val v = Vec(1,2)
     val expected = Rect(1,2,10,10)
-    assert(r + v === expected)
+    val result = r + v
+    assert(result.left === expected.left)
+    assert(result.top === expected.top)
+    assert(result.width === expected.width)
+    assert(result.height === expected.height)
   }
   
   test("subtracts a Vec") {
     val r = Rect(0,0,10,10)
     val v = Vec(1,2)
     val expected = Rect(-1,-2,10,10)
-    assert(r - v === expected)
+    val result = r - v
+    assert(result.left === expected.left)
+    assert(result.top === expected.top)
+    assert(result.width === expected.width)
+    assert(result.height === expected.height)
   }
 }


### PR DESCRIPTION
Adds the ability to change the position of a `Circle` or `Rect` by adding/subtracting a `Vec`.

I'm working on a Pong clone, and it would be nice to do something like this:

```scala
var ball = Circle(centerHeight, centerWidth, ballRadius)
// ...
ball = ball + Vec(1, 1)

var player1 = Rect(0, 0, PaddleWidth, PaddleHeight)
// ...
player1 = player1 + Vec(0, 1)
```

instead of having to unpack and repack the guts of the object like so:

```scala
ball = Circle(ball.center + Vec(1, 1), ballRadius)

val newPlayerPos = player1.center + Vec(1, 1)
player1 = Rect(newPlayerPos.x, newPlayerPos.y, PaddleWidth, PaddleHeight)
```

Ran `verifyCI` locally to ensure tests pass.